### PR TITLE
Add roles selection menus

### DIFF
--- a/PhysBot.py
+++ b/PhysBot.py
@@ -16,7 +16,9 @@ async def create_http_session(loop):
 async def create_db_connection(db_name):
     """Create the connection to the database."""
 
-    return await aiosqlite.connect(db_name, detect_types=1)  # 1: parse declared types
+    db = await aiosqlite.connect(db_name, detect_types=1)  # 1: parse declared types
+    await db.execute("PRAGMA foreign_keys = ON")  # allow for cascade deletion
+    return db
 
 
 class PhysBot(commands.Bot):

--- a/PhysBot.py
+++ b/PhysBot.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
         "cogs.games",
         "cogs.Information",
         "cogs.Moderation",
+        "cogs.Roles",
         "cogs.TeX",
         "cogs.WolframAlpha",
         "cogs.Voice",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pour contribuer au niveau du code, il va être nécessaire de pouvoir exécuter 
 La section qui suit détaille le processus à suivre.
 
 ### Dépendances
-Avant tout, pour pouvoir exécuter le bot, il vous faut Python 3.8+ ainsi que les modules énumérés dans `requirements.txt`.
+Avant tout, pour pouvoir exécuter le bot, il vous faut Python 3.9+ ainsi que les modules énumérés dans `requirements.txt`.
 
 Il est possible d'installer rapidement tous les modules avec la commande `pip install -r requirements.txt`
 Il est recommandé de créer un environement virtuel pour le bot (voir [le guide conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html), par exemple).

--- a/cogs/Moderation/moderation.py
+++ b/cogs/Moderation/moderation.py
@@ -105,11 +105,15 @@ class Moderation(commands.Cog):
             return
 
         data = defaultdict(lambda: None)
+        edited_at = (
+            parse_time(payload.data.get("edited_timestamp")) or discord.utils.utcnow()
+        )
+
         data.update(
             {
                 "channel_id": payload.channel_id,
                 "message_id": payload.message_id,
-                "edited_at": parse_time(payload.data.get("edited_timestamp")),
+                "edited_at": edited_at,
                 "content_after": payload.data["content"],  # will always be present
                 "guild_id": payload.data.get("guild_id"),
             }

--- a/cogs/Roles/__init__.py
+++ b/cogs/Roles/__init__.py
@@ -1,0 +1,5 @@
+from .roles import Roles
+
+
+def setup(bot):
+    bot.add_cog(Roles(bot))

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -3,6 +3,14 @@ from discord.ext import commands
 from . import views
 
 
+class RolesFlags(commands.FlagConverter):
+    channel: discord.TextChannel = commands.flag(default=lambda ctx: ctx.channel)
+    content: str = commands.flag(
+        default="Select from the following roles:", aliases=["message"]
+    )
+    roles: tuple[discord.Role, ...]  # able to add more than one with the flag
+
+
 class Roles(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -14,6 +22,6 @@ class Roles(commands.Cog):
             self.persistent_views_added = True
 
     @commands.command()
-    async def roles(self, ctx, roles: commands.Greedy[discord.Role]):
-        view = views.RolesView(roles)
-        await ctx.send("roles", view=view)
+    async def roles(self, ctx, *, flags: RolesFlags):
+        view = views.RolesView(flags.roles)
+        await flags.channel.send(flags.content, view=view)

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -6,6 +6,12 @@ from . import views
 class Roles(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        self.persistent_views_added = False
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        if not self.persistent_views_added:
+            self.persistent_views_added = True
 
     @commands.command()
     async def roles(self, ctx, roles: commands.Greedy[discord.Role]):

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -25,7 +25,7 @@ class Roles(commands.Cog):
             self.persistent_views_added = True
 
     @commands.has_guild_permissions(manage_roles=True)
-    @commands.group()
+    @commands.group(aliases=["role"])
     async def roles(self, ctx):
         """Commands to create and manage role selection menus."""
 

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -13,7 +13,7 @@ class RolesCreateFlags(commands.FlagConverter):
     roles: tuple[discord.Role, ...]  # able to add more than one with the flag
 
 
-class RolesAddDeleteFlags(commands.FlagConverter):
+class RolesAddRemoveFlags(commands.FlagConverter):
     message: Union[discord.Message, discord.PartialMessage]
     roles: tuple[discord.Role, ...]  # able to add more than one with the flag
 
@@ -56,24 +56,24 @@ class Roles(commands.Cog):
         await self.save_persistent_view(view, message)
 
     @roles.command(name="add")
-    async def roles_add(self, ctx, *, flags: RolesAddDeleteFlags):
+    async def roles_add(self, ctx, *, flags: RolesAddRemoveFlags):
         """Add a role to the selection list."""
 
-        execute = self.roles_add_delete("save")
+        execute = self.roles_add_remove("save")
         embed = await execute(flags.message, flags.roles)
 
         await ctx.reply(embed=embed)
 
-    @roles.command(name="delete")
-    async def roles_delete(self, ctx, *, flags: RolesAddDeleteFlags):
-        """Delete a role from the selection list."""
+    @roles.command(name="remove")
+    async def roles_remove(self, ctx, *, flags: RolesAddRemoveFlags):
+        """Remove a role from the selection list."""
 
-        execute = self.roles_add_delete("delete")
+        execute = self.roles_add_remove("delete")
         embed = await execute(flags.message, flags.roles)
 
         await ctx.reply(embed=embed)
 
-    def roles_add_delete(self, method):
+    def roles_add_remove(self, method):
         async def execute(message, roles):
 
             view_data = await self._get_view_from_message(message)
@@ -98,8 +98,8 @@ class Roles(commands.Cog):
         return execute
 
     @roles_add.error
-    @roles_delete.error
-    async def roles_add_delete_error(self, ctx, error):
+    @roles_remove.error
+    async def roles_add_remove_error(self, ctx, error):
         if isinstance(error, (commands.RoleNotFound, commands.MissingFlagArgument,),):
             await ctx.reply(error)
 

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -1,0 +1,13 @@
+import discord
+from discord.ext import commands
+from . import views
+
+
+class Roles(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def roles(self, ctx, roles: commands.Greedy[discord.Role]):
+        view = views.RolesView(roles)
+        await ctx.send("roles", view=view)

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -23,9 +23,15 @@ class Roles(commands.Cog):
             self.persistent_views_added = True
 
     @commands.command()
-    async def roles(self, ctx, *, flags: RolesFlags):
+    async def select(self, ctx, *, flags: RolesFlags):
         view = views.RolesView(flags.roles)
         await flags.channel.send(flags.content, view=view)
+
+    @commands.command()
+    async def toggle(self, ctx, *, flags: RolesFlags):
+        view = views.RolesToggleView(flags.roles)
+        await flags.channel.send(flags.content, view=view)
+
     @tasks.loop(count=1)
     async def _create_tables(self):
         await self.bot.db.execute(

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -130,6 +130,29 @@ class Roles(commands.Cog):
 
         await ctx.reply(embed=embed)
 
+    @roles.command(name="edit")
+    async def roles_edit(
+        self,
+        ctx,
+        message: Union[discord.Message, discord.PartialMessage],
+        *,
+        content: str,
+    ):
+        """Edit the content of a role selection message."""
+
+        await message.edit(content=content)
+
+        embed = discord.Embed(
+            color=discord.Color.green(),
+            title="Successfully edited message.",
+            description=(
+                f"[Message]({message.jump_url}) content was edited to\n"
+                f"```\n{content}\n```"
+            ),
+        )
+
+        await ctx.reply(embed=embed)
+
     async def load_persistent_views(self):
         for view_data in await self._get_all_views():
             self.bot.add_view(

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -41,15 +41,38 @@ class Roles(commands.Cog):
 
     @roles.command(name="select")
     async def roles_select(self, ctx, *, flags: RolesCreateFlags):
-        """Create a role selection menu, to select many roles from the list."""
+        """Create a role selection menu, to select many roles from the list.
+        Members can select many roles from the list to assign to themselves.
 
+        Flags:
+            channel: The channel to send the message to. Channel name, ID or
+                     mention works
+            content: The content of the message to be sent.
+                alias: message
+            roles: A space-separated list of roles. Role name, ID or mention works.
+
+        Ex: roles select roles: @Role1 @Role2 message: Select some roles!
+            channel: #general
+        """
         view = views.RolesView(flags.roles)
         message = await flags.channel.send(flags.content, view=view)
         await self.save_persistent_view(view, message)
 
     @roles.command(name="toggle")
     async def roles_toggle(self, ctx, *, flags: RolesCreateFlags):
-        """Create a role toggle menu, to select only one role from the list."""
+        """Create a role toggle menu, to select only one role from the list.
+        Members can select only one role from the list to assign to themselves.
+
+        Flags:
+            channel: The channel to send the message to. Channel name, ID or
+                     mention works
+            content: The content of the message to be sent.
+                alias: message
+            roles: A space-separated list of roles. Role name, ID or mention works.
+
+        Ex: roles toggle roles: @Role1 @Role2 message: Select one roles!
+            channel: #general
+        """
 
         view = views.RolesToggleView(flags.roles)
         message = await flags.channel.send(flags.content, view=view)
@@ -57,7 +80,14 @@ class Roles(commands.Cog):
 
     @roles.command(name="add")
     async def roles_add(self, ctx, *, flags: RolesAddRemoveFlags):
-        """Add a role to the selection list."""
+        """Add a role to the selection list.
+
+        Flags:
+            message: ID or URL to the message containing a selection menu.
+            roles: A space-separated list of roles. Role name, ID or mention works.
+
+        Ex: roles add message: 123456789123456789 roles: @Role1 @Role2
+        """
 
         execute = self.roles_add_remove("save")
         embed = await execute(flags.message, flags.roles)
@@ -66,7 +96,14 @@ class Roles(commands.Cog):
 
     @roles.command(name="remove")
     async def roles_remove(self, ctx, *, flags: RolesAddRemoveFlags):
-        """Remove a role from the selection list."""
+        """Remove a role from the selection list.
+
+        Flags:
+            message: ID or URL to the message containing a selection menu.
+            roles: A space-separated list of roles. Role name, ID or mention works.
+
+        Ex: roles remove message: 123456789123456789 roles: @Role1 @Role2
+        """
 
         execute = self.roles_add_remove("delete")
         embed = await execute(flags.message, flags.roles)
@@ -117,7 +154,9 @@ class Roles(commands.Cog):
     async def roles_delete(
         self, ctx, message: Union[discord.Message, discord.PartialMessage]
     ):
-        """Delete a role selection menu."""
+        """Delete a selection menu and its message.
+        Argument `message` needs to be the mesage ID or URL.
+        """
 
         await self._delete_view_from_message(message)
         await message.delete()
@@ -138,7 +177,10 @@ class Roles(commands.Cog):
         *,
         content: str,
     ):
-        """Edit the content of a role selection message."""
+        """Edit the content of a role selection message.
+        Argument `message` needs to be the mesage ID or URL. It must be a
+        message sent by the bot!
+        """
 
         await message.edit(content=content)
 

--- a/cogs/Roles/roles.py
+++ b/cogs/Roles/roles.py
@@ -22,15 +22,39 @@ class Roles(commands.Cog):
         if not self.persistent_views_added:
             self.persistent_views_added = True
 
-    @commands.command()
-    async def select(self, ctx, *, flags: RolesFlags):
+    @commands.has_guild_permissions(manage_roles=True)
+    @commands.group()
+    async def roles(self, ctx):
+        """Commands to create and manage role selection menus."""
+
+        if ctx.invoked_subcommand is None:
+            await ctx.send_help(ctx.command)
+
+    @roles.command(name="select")
+    async def roles_select(self, ctx, *, flags: RolesFlags):
+        """Create a role selection menu, to select many roles from the list."""
+
         view = views.RolesView(flags.roles)
         await flags.channel.send(flags.content, view=view)
 
-    @commands.command()
-    async def toggle(self, ctx, *, flags: RolesFlags):
+    @roles.command(name="toggle")
+    async def roles_toggle(self, ctx, *, flags: RolesFlags):
+        """Create a role toggle menu, to select only one role from the list."""
+
         view = views.RolesToggleView(flags.roles)
         await flags.channel.send(flags.content, view=view)
+
+    @roles.command(name="add")
+    async def roles_add(self, ctx):
+        """Add a role to the selection list."""
+
+        pass
+
+    @roles.command(name="delete")
+    async def roles_delete(self, ctx):
+        """Delete a role from the selection list."""
+
+        pass
 
     @tasks.loop(count=1)
     async def _create_tables(self):
@@ -49,7 +73,7 @@ class Roles(commands.Cog):
             CREATE TABLE IF NOT EXISTS roles_component(
                 component_id TEXT NOT NULL,
                 name         TEXT NOT NULL,
-                view_id INTEGER NOT NULL,
+                view_id      INTEGER NOT NULL,
                 FOREIGN KEY (view_id)
                     REFERENCES roles_view (view_id)
             )

--- a/cogs/Roles/views.py
+++ b/cogs/Roles/views.py
@@ -30,13 +30,13 @@ class RolesView(View):
 
         if components_id is None:
             components_id = {
-                "select_id": token_hex(16),
-                "add_id": token_hex(16),
-                "remove_id": token_hex(16),
+                "select": token_hex(16),
+                "add": token_hex(16),
+                "remove": token_hex(16),
             }
         self.components_id = components_id
 
-        select = RolesSelect(roles, custom_id=components_id["select_id"])
+        select = RolesSelect(roles, custom_id=components_id["select"])
         self.add_item(select)
         self.selected_roles = {}
 
@@ -44,7 +44,7 @@ class RolesView(View):
             label="Add",
             style=ButtonStyle.green,
             emoji="\N{HEAVY PLUS SIGN}",
-            custom_id=components_id["add_id"],
+            custom_id=components_id["add"],
             row=4,
         )
         add.callback = self.button_callback("add_roles")
@@ -54,7 +54,7 @@ class RolesView(View):
             label="Remove",
             style=ButtonStyle.red,
             emoji="\N{HEAVY MINUS SIGN}",
-            custom_id=components_id["remove_id"],
+            custom_id=components_id["remove"],
             row=4,
         )
         remove.callback = self.button_callback("remove_roles")
@@ -113,20 +113,20 @@ class RolesToggleView(View):
 
         if components_id is None:
             components_id = {
-                "select_id": token_hex(16),
-                "clear_id": token_hex(16),
+                "select": token_hex(16),
+                "clear": token_hex(16),
             }
         self.components_id = components_id
         self.roles = roles
 
-        select = RolesToggleSelect(roles, custom_id=components_id["select_id"])
+        select = RolesToggleSelect(roles, custom_id=components_id["select"])
         self.add_item(select)
 
         clear = Button(
             label="Clear",
             style=ButtonStyle.red,
             emoji="\N{HEAVY MINUS SIGN}",
-            custom_id=components_id["clear_id"],
+            custom_id=components_id["clear"],
             row=4,
         )
         clear.callback = self.clear_callback

--- a/cogs/Roles/views.py
+++ b/cogs/Roles/views.py
@@ -55,3 +55,14 @@ class RolesView(View):
             f"Changing roles {self.selected_roles[member]} to {repr(member)}",
             ephemeral=True,
         )
+
+    async def on_error(
+        self, error: Exception, item: Item, interaction: discord.Interaction
+    ):
+        if isinstance(error, KeyError):
+            await interaction.response.send_message(
+                "There was an error. You need to select at least one role.",
+                ephemeral=True,
+            )
+        else:
+            raise error

--- a/cogs/Roles/views.py
+++ b/cogs/Roles/views.py
@@ -1,0 +1,58 @@
+import discord
+from discord import ButtonStyle
+from discord.ui import View, Button, Select
+
+
+class RolesSelect(Select):
+    def __init__(self, roles, toggle=False):
+        options = [discord.SelectOption(label=role.name) for role in roles]
+        self.id_map = {role.name: role.id for role in roles}
+        super().__init__(
+            placeholder="Select roles",
+            options=options,
+            max_values=1 if toggle else len(options),
+            custom_id="rolesview:select",
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        guild = interaction.guild
+        selected_roles = [guild.get_role(self.id_map[name]) for name in self.values]
+        self.view.selected_roles[interaction.user] = selected_roles
+
+
+class RolesView(View):
+    def __init__(self, roles: list[discord.Role]):
+        select = RolesSelect(roles)
+        super().__init__()
+        self.add_item(select)
+        self.selected_roles = {}
+
+    @discord.ui.button(
+        label="Add",
+        style=ButtonStyle.green,
+        emoji="\N{HEAVY PLUS SIGN}",
+        custom_id="rolesview:add",
+        row=4,
+    )
+    async def add_roles(self, button: Button, interaction: discord.Interaction):
+        member = interaction.user
+        await member.add_roles(*self.selected_roles[member])
+        await interaction.response.send_message(
+            f"Adding roles {self.selected_roles[member]} to {repr(member)}",
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Remove",
+        style=ButtonStyle.red,
+        emoji="\N{HEAVY MINUS SIGN}",
+        custom_id="rolesview:remove",
+        row=4,
+    )
+    async def remove_roles(self, button: Button, interaction: discord.Interaction):
+        member = interaction.user
+        await member.remove_roles(*self.selected_roles[member])
+        await interaction.response.send_message(
+            f"Removing roles {self.selected_roles[member]} to {repr(member)}",
+            ephemeral=True,
+        )

--- a/cogs/Roles/views.py
+++ b/cogs/Roles/views.py
@@ -35,12 +35,7 @@ class RolesView(View):
         row=4,
     )
     async def add_roles(self, button: Button, interaction: discord.Interaction):
-        member = interaction.user
-        await member.add_roles(*self.selected_roles[member])
-        await interaction.response.send_message(
-            f"Adding roles {self.selected_roles[member]} to {repr(member)}",
-            ephemeral=True,
-        )
+        await self.button_callback("add_roles", interaction)
 
     @discord.ui.button(
         label="Remove",
@@ -50,9 +45,13 @@ class RolesView(View):
         row=4,
     )
     async def remove_roles(self, button: Button, interaction: discord.Interaction):
+        await self.button_callback("remove_roles", interaction)
+
+    async def button_callback(self, method: str, interaction: discord.Interaction):
         member = interaction.user
-        await member.remove_roles(*self.selected_roles[member])
+        add_remove_roles = getattr(member, method)
+        await add_remove_roles(*self.selected_roles[member])
         await interaction.response.send_message(
-            f"Removing roles {self.selected_roles[member]} to {repr(member)}",
+            f"Changing roles {self.selected_roles[member]} to {repr(member)}",
             ephemeral=True,
         )

--- a/cogs/Roles/views.py
+++ b/cogs/Roles/views.py
@@ -35,6 +35,7 @@ class RolesView(View):
                 "remove": token_hex(16),
             }
         self.components_id = components_id
+        self.roles = roles
 
         select = RolesSelect(roles, custom_id=components_id["select"])
         self.add_item(select)

--- a/cogs/Roles/views.py
+++ b/cogs/Roles/views.py
@@ -102,7 +102,7 @@ class RolesToggleSelect(RolesSelect):
         await member.add_roles(selected_role)
 
         await interaction.response.send_message(
-            f"Changing roles {selected_role.mention} for member {member.mention}.",
+            f"Setting role {selected_role.mention} for member {member.mention}.",
             ephemeral=True,
         )
 

--- a/cogs/Roles/views.py
+++ b/cogs/Roles/views.py
@@ -6,11 +6,13 @@ from discord.ui import View, Button, Select, Item
 
 
 class RolesSelect(Select):
-    def __init__(self, roles, custom_id, toggle=False):
+    placeholder = "Select roles"
+
+    def __init__(self, roles, *, custom_id, toggle=False):
         options = [discord.SelectOption(label=role.name) for role in roles]
         self.id_map = {role.name: role.id for role in roles}
         super().__init__(
-            placeholder="Select roles",
+            placeholder=self.placeholder,
             options=options,
             max_values=1 if toggle else len(options),
             custom_id=custom_id,
@@ -34,7 +36,7 @@ class RolesView(View):
             }
         self.components_id = components_id
 
-        select = RolesSelect(roles, components_id["select_id"])
+        select = RolesSelect(roles, custom_id=components_id["select_id"])
         self.add_item(select)
         self.selected_roles = {}
 
@@ -65,11 +67,77 @@ class RolesView(View):
             await add_remove_roles(*self.selected_roles[member])
             roles_str = ", ".join(role.mention for role in self.selected_roles[member])
             await interaction.response.send_message(
-                f"Changing roles {roles_str} for member {member.mention}",
+                f"Changing roles {roles_str} for member {member.mention}.",
                 ephemeral=True,
             )
 
         return callback
+
+    async def on_error(
+        self, error: Exception, item: Item, interaction: discord.Interaction
+    ):
+        if isinstance(error, KeyError):
+            await interaction.response.send_message(
+                "There was an error. You need to select at least one role.",
+                ephemeral=True,
+            )
+        else:
+            raise error
+
+
+class RolesToggleSelect(RolesSelect):
+    placeholder = "Select one role"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, toggle=True)
+
+    async def callback(self, interaction: discord.Interaction):
+        guild = interaction.guild
+        member = interaction.user
+        roles = [guild.get_role(id) for id in self.id_map.values()]
+        # always exactly one value selected
+        selected_role = guild.get_role(self.id_map[self.values[0]])
+
+        await member.remove_roles(*roles)
+        await member.add_roles(selected_role)
+
+        await interaction.response.send_message(
+            f"Changing roles {selected_role.mention} for member {member.mention}.",
+            ephemeral=True,
+        )
+
+
+class RolesToggleView(View):
+    def __init__(self, roles: list[discord.Role], components_id: dict[str, str] = None):
+        super().__init__(timeout=None)
+
+        if components_id is None:
+            components_id = {
+                "select_id": token_hex(16),
+                "clear_id": token_hex(16),
+            }
+        self.components_id = components_id
+        self.roles = roles
+
+        select = RolesToggleSelect(roles, custom_id=components_id["select_id"])
+        self.add_item(select)
+
+        clear = Button(
+            label="Clear",
+            style=ButtonStyle.red,
+            emoji="\N{HEAVY MINUS SIGN}",
+            custom_id=components_id["clear_id"],
+            row=4,
+        )
+        clear.callback = self.clear_callback
+        self.add_item(clear)
+
+    async def clear_callback(self, interaction: discord.Interaction):
+        member = interaction.user
+        await member.remove_roles(*self.roles)
+        await interaction.response.send_message(
+            f"Cleared the roles for member {member.mention}.", ephemeral=True,
+        )
 
     async def on_error(
         self, error: Exception, item: Item, interaction: discord.Interaction

--- a/cogs/Roles/views.py
+++ b/cogs/Roles/views.py
@@ -23,7 +23,7 @@ class RolesSelect(Select):
 class RolesView(View):
     def __init__(self, roles: list[discord.Role]):
         select = RolesSelect(roles)
-        super().__init__()
+        super().__init__(timeout=None)
         self.add_item(select)
         self.selected_roles = {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiosqlite==0.17.0
 asyncpraw==7.4.0
-discord.py==1.7.3
+git+git://github.com/Rapptz/discord.py.git@master
 Unidecode==1.3.2
 git+git://github.com/Rapptz/discord-ext-menus.git
 git+git://github.com/Snaptraks/aiowolframalpha.git


### PR DESCRIPTION
Add commands 

`role|roles`
`role|roles select`
`role|roles toggle`
`role|roles add`
`role|roles remove`
`role|roles edit`
`role|roles delete`

Role selection menus are persistent (no timeout) and are saved/loaded at startup.

This PR also needs a dependency update for discord.py (2.0.0a) and Python (3.9+)